### PR TITLE
Fix deploy workflow: install bs4_book deps and required LaTeX packages

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -19,8 +19,10 @@ jobs:
         run: Rscript -e 'install.packages("tinytex")'
       - name: Setup tinytex
         run: Rscript -e 'tinytex::install_tinytex()'
-      - name: Install rmarkdown
-        run: Rscript -e 'install.packages(c("rmarkdown","bookdown"))'
+      - name: Install R packages
+        run: Rscript -e 'install.packages(c("rmarkdown","bookdown","downlit","bslib","xml2"))'
+      - name: Install required LaTeX packages
+        run: Rscript -e 'tinytex::tlmgr_install(c("chapterbib","footmisc","eepic"))'
       - name: Render Book
         run: Rscript -e 'bookdown::render_book("index.Rmd")'
       - uses: actions/upload-artifact@v4

--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -1,3 +1,4 @@
 output_dir: "_book"
 book_filename: "Coursepack-MY451"
 chapter_name: "Chapter "
+delete_merged_file: true


### PR DESCRIPTION
## Summary

The deploy workflow has been failing since at least PR #13's merge — the GitHub Pages site at <https://lse-methodology.github.io/MY451/> has not been updated by CI. Two distinct failures were blocking it:

- **Missing R packages**: `bs4_book` requires `downlit`, `bslib`, and `xml2`. The most recent run (after the layout-modernization PR was merged) failed with `Must install the following packages to use bs4_book(): downlit, xml2`.
- **Missing LaTeX package**: the PDF build needs `chapterbib.sty`. Tinytex's auto-install ran into CTAN mirror version drift ("Remote database... seems to be older than the local installation") and aborted, killing the PDF build and preventing the artifact upload / Pages deploy.

This PR:

- Adds `downlit`, `bslib`, `xml2` to the R install step.
- Pre-installs `chapterbib`, `footmisc`, `eepic` via `tinytex::tlmgr_install(...)` before render, so the PDF build doesn't depend on tinytex's auto-install at render time.
- Sets `delete_merged_file: true` in `_bookdown.yml` so a failed render doesn't leave `Coursepack-MY451.Rmd` behind to block the next attempt.

## Test plan

- [ ] Merge this PR and watch the workflow run to completion.
- [ ] Confirm the run succeeds end-to-end (Render Book → upload-artifact → checkout-and-deploy).
- [ ] Open <https://lse-methodology.github.io/MY451/> and confirm the new `bs4_book` layout is live (sidebar TOC, search, light/dark toggle).
- [ ] Confirm the PDF download still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)