### PR TITLE
Fix deploy step and add status badges

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -48,10 +48,11 @@ jobs:
          # Destination path
          path: _book # optional
      - name: Deploy to GitHub Pages
-       uses: Cecilapp/GitHub-Pages-deploy@master
+       uses: Cecilapp/GitHub-Pages-deploy@v3
+       with:
+          email: ${{ secrets.EMAIL }}             # must be a verified email
+          build_dir: _book                        # bookdown's output directory
        env:
-          EMAIL: ${{ secrets.EMAIL }}               # must be a verified email
-          GH_TOKEN: ${{ secrets.GH_PAT }} # https://github.com/settings/tokens
-          BUILD_DIR: _book/                     # "_site/" by default
+          GH_TOKEN: ${{ secrets.GH_PAT }}         # https://github.com/settings/tokens
     
  

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
 # MY451 Coursepack source
 
+[![Render and deploy](https://github.com/LSE-Methodology/MY451/actions/workflows/deploy_bookdown.yml/badge.svg?branch=master)](https://github.com/LSE-Methodology/MY451/actions/workflows/deploy_bookdown.yml)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/lse-methodology-my451/deploy-status)](https://app.netlify.com/sites/lse-methodology-my451/deploys)
+
 Source for the course pack and main text of **MY451 — Introduction to Quantitative Analysis**, taught in the Department of Methodology at the London School of Economics and Political Science.
 
 Published at: <https://lse-methodology.github.io/MY451/>


### PR DESCRIPTION
## Summary

Two related fixes:

### 1. Fix the deploy step

PR #15 got the render working, but the deploy still failed with `cp: can't stat '_site/*': No such file or directory`. The reason: `Cecilapp/GitHub-Pages-deploy` now reads `build_dir` and `email` from `with:` inputs, not from env vars. The old workflow passed them via env, the action ignored them and fell back to the default `_site`, which doesn't exist (bookdown writes to `_book`).

This PR moves `email` and `build_dir` into `with:` and pins the action to `@v3` (replacing the unpinned `@master`). `GH_TOKEN` still goes via env, which is what the action expects.

### 2. Add status badges to the README

Two badges at the top of `readme.md`:

- **Render and deploy** — GitHub Actions workflow status on `master`.
- **Netlify Status** — Netlify production deploy status.

Either turning red means the public site is not updating.

## How the badges behave on PRs

GitHub renders the README on every PR, so the badges are visible from any PR — but a few things to know:

- The **GitHub Actions** badge URL is pinned to `?branch=master`, so it always reflects the master deploy regardless of which PR you're viewing it from. For per-PR build status, GitHub already shows checks at the bottom of every PR (look for "All checks have passed" / "Some checks were not successful").
- The **Netlify** badge shows the latest production deploy. For per-PR previews, Netlify already posts a "Deploy preview ready" check on every PR (with a link to the preview URL).

If you want a badge that flips per-PR, that's possible but needs more work (a Netlify access token in repo secrets, plus context-specific badge URLs). Happy to do that as a follow-up — just say the word.

## Test plan

- [ ] Merge this PR.
- [ ] Confirm the workflow run succeeds end-to-end (Render-Book + checkout-and-deploy both green).
- [ ] Open <https://lse-methodology.github.io/MY451/> and confirm the new bs4_book layout is live.
- [ ] Confirm both badges in the rendered README show green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)