### PR TITLE
Use built-in GITHUB_TOKEN for Pages deploy

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -37,22 +37,22 @@ jobs:
   checkout-and-deploy:
    runs-on: ubuntu-latest
    needs: bookdown
+   permissions:
+     contents: write
    steps:
      - name: Checkout
-       uses: actions/checkout@master
+       uses: actions/checkout@v4
      - name: Download artifact
        uses: actions/download-artifact@v4.1.3
        with:
-         # Artifact name
-         name: _book # optional
-         # Destination path
-         path: _book # optional
+         name: _book
+         path: _book
      - name: Deploy to GitHub Pages
        uses: Cecilapp/GitHub-Pages-deploy@v3
        with:
           email: ${{ secrets.EMAIL }}             # must be a verified email
           build_dir: _book                        # bookdown's output directory
        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}         # https://github.com/settings/tokens
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # built-in token, never expires
     
  


### PR DESCRIPTION
## Summary

The PR #16 run got the deploy further than ever — render succeeded, gh-pages was cloned, the bs4_book files were committed — and then the final `git push` failed:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/LSE-Methodology/MY451.git/'
```

The `GH_PAT` repo secret holds an expired Personal Access Token. Rather than mint a new one and repeat this every 90 days, this PR switches to the auto-injected `GITHUB_TOKEN`:

- Replace `GH_TOKEN: ${{ secrets.GH_PAT }}` with `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` in the deploy job.
- Add `permissions: contents: write` on the deploy job so `GITHUB_TOKEN` can push to `gh-pages` (it is read-only by default).
- Also bump `actions/checkout@master` (unpinned) to `actions/checkout@v4` while editing this job.

## Follow-up housekeeping (not in this PR)

- The `GH_PAT` repo secret is no longer referenced and can be deleted at Settings → Secrets and variables → Actions.
- `EMAIL` is still used and should stay.

## Test plan

- [ ] Merge.
- [ ] Watch the workflow run finish green (both jobs).
- [ ] Confirm <https://lse-methodology.github.io/MY451/> serves the new bs4_book layout.
- [ ] Confirm the README badges both show passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)