### PR TITLE
Switch deploy to peaceiris/actions-gh-pages

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -30,29 +30,28 @@ jobs:
           name: _book
           path: _book/
   
-# Need to first create an empty gh-pages branch
-# see https://pkgdown.r-lib.org/reference/deploy_site_github.html
-# and also add secrets for a GH_PAT and EMAIL to the repository
-# gh-action from Cecilapp/GitHub-Pages-deploy
+# Publishes _book/ to the gh-pages branch via peaceiris/actions-gh-pages.
+# Uses the built-in GITHUB_TOKEN (no PAT required); the deploy job
+# needs `permissions: contents: write` to push to gh-pages.
   checkout-and-deploy:
-   runs-on: ubuntu-latest
-   needs: bookdown
-   permissions:
-     contents: write
-   steps:
-     - name: Checkout
-       uses: actions/checkout@v4
-     - name: Download artifact
-       uses: actions/download-artifact@v4.1.3
-       with:
-         name: _book
-         path: _book
-     - name: Deploy to GitHub Pages
-       uses: Cecilapp/GitHub-Pages-deploy@v3
-       with:
-          email: ${{ secrets.EMAIL }}             # must be a verified email
-          build_dir: _book                        # bookdown's output directory
-       env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # built-in token, never expires
+    runs-on: ubuntu-latest
+    needs: bookdown
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v4.1.3
+        with:
+          name: _book
+          path: _book
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_book
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
     
  


### PR DESCRIPTION
## Summary

The deploy job in PR #17 still failed at the final `git push` with `Invalid username or token`. Root cause: `Cecilapp/GitHub-Pages-deploy@v3`'s entrypoint builds the push URL as `https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/...` — the PAT format. That works with a Personal Access Token (when the actor IS the token owner), but it does not work reliably with the built-in `GITHUB_TOKEN`. The action also reads `$GITHUB_TOKEN` from env, not the `$GH_TOKEN` env var we'd been passing in (we got lucky on the clone step earlier because the repo is public; the push step needs real auth).

Rather than keep patching Cecilapp, this PR swaps in [`peaceiris/actions-gh-pages`](https://github.com/peaceiris/actions-gh-pages) — the de facto standard gh-pages publisher. It's actively maintained, accepts `GITHUB_TOKEN` directly, and the config is shorter (just `publish_dir` + `github_token`). Publish commits are authored by `github-actions[bot]`.

## Test plan

- [ ] Merge.
- [ ] Watch the workflow run finish green end-to-end.
- [ ] Open <https://lse-methodology.github.io/MY451/> and confirm the new bs4_book layout is finally live.
- [ ] Both README badges go green.

## Note

If this still fails: check Settings → Actions → General → Workflow permissions and confirm "Read and write permissions" is selected (or that the per-job `permissions: contents: write` we set is being honored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)